### PR TITLE
Serialize deeply nested selector correctly

### DIFF
--- a/lib/origin/selector.rb
+++ b/lib/origin/selector.rb
@@ -67,6 +67,7 @@ module Origin
     def evolve_multi(value)
       value.map do |val|
         Hash[val.map do |key, _value|
+          _value = evolve_multi(_value) if multi_selection?(key)
           name, serializer = storage_pair(key)
           [ normalized_key(name, serializer), evolve(serializer, _value) ]
         end]

--- a/spec/origin/selector_spec.rb
+++ b/spec/origin/selector_spec.rb
@@ -199,12 +199,14 @@ describe Origin::Selector do
             )
           end
 
-          before do
+          it "stores the serialized field in the selector by database name" do
             selector.send(method, "id", "1")
+            selector["_id"].should eq(1)
           end
 
-          it "stores the serialized field in the selector by database name" do
-            selector["_id"].should eq(1)
+          it "stores the serialized field when selector is deeply nested" do
+            selector.send(method, "$or", [{'$and' => [{'_id' => '5'}]}])
+            selector['$or'][0]['$and'][0]['_id'].should eq(5)
           end
         end
       end


### PR DESCRIPTION
For example:
  {'$and' => [{'$or' => [{_id: '50412b6b555389e152000002'}]}]}

Before we will always get nothing because '_id' serialized as string.
Now it is serialized into ObjectId regardless of the level of nesting.
