### PR TITLE
$not criterion negation for regular expressions

### DIFF
--- a/lib/origin/extensions/string.rb
+++ b/lib/origin/extensions/string.rb
@@ -59,7 +59,7 @@ module Origin
       #
       # @since 1.0.0
       def specify(value, negating = false)
-        { self => value }
+        (negating && value.regexp?) ? { self => { "$not" => value } } : { self => value }
       end
 
       # Get the string as a sort direction.

--- a/lib/origin/extensions/symbol.rb
+++ b/lib/origin/extensions/symbol.rb
@@ -17,7 +17,7 @@ module Origin
       #
       # @since 1.0.0
       def specify(value, negating = false)
-        { self => value }
+        (negating && value.regexp?) ? { self => { "$not" => value } } : { self => value }
       end
 
       # Get the symbol as a sort direction.

--- a/lib/origin/key.rb
+++ b/lib/origin/key.rb
@@ -57,7 +57,7 @@ module Origin
     def specify(object, negating = false)
       value = block ? block[object] : object
       expression = { operator => expanded ? { expanded => value } : value }
-      { name.to_s => negating ? { "$not" => expression } : expression }
+      { name.to_s => (negating && operator != "$not") ? { "$not" => expression } : expression }
     end
 
     # Get the key as raw Mongo sorting options.

--- a/lib/origin/selectable.rb
+++ b/lib/origin/selectable.rb
@@ -352,12 +352,21 @@ module Origin
     # @example Negate the selection.
     #   selectable.not.in(field: [ 1, 2 ])
     #
+    # @example Add the $not criterion.
+    #   selectable.not(name: /Bob/)
+    #
+    # @example Execute a $not in a where query.
+    #   selectable.where(:field.not => /Bob/)
+    #
+    # @param [ Hash ] criterion The field/value pairs to negate.
+    #
     # @return [ Selectable ] The negated selectable.
     #
     # @since 1.0.0
-    def not
-      tap { |query| query.negating = true }
+    def not(*criterion)
+      (criterion.size == 0) ? tap { |query| query.negating = true } : __override__(criterion.first, "$not")
     end
+    key :not, :override, "$not"
 
     # Adds $or selection to the selectable.
     #

--- a/spec/origin/extensions/string_spec.rb
+++ b/spec/origin/extensions/string_spec.rb
@@ -168,6 +168,44 @@ describe String do
     it "returns the string with the value" do
       specified.should eq({ "field" => 10 })
     end
+
+    context "with a regexp" do
+
+      let(:specified) do
+        "field".specify(/test/)
+      end
+
+      it "returns the symbol with the value" do
+        specified.should eq({ "field" => /test/ })
+      end
+
+    end
+
+    context "when negated" do
+      context "with a regexp" do
+
+        let(:specified) do
+          "field".specify(/test/, true)
+        end
+
+        it "returns the string with the value negated" do
+          specified.should eq({ "field" => { "$not" => /test/ } })
+        end
+
+      end
+
+      context "with anything else" do
+
+        let(:specified) do
+          "field".specify('test', true)
+        end
+
+        it "returns the string with the value" do
+          specified.should eq({ "field" => 'test' })
+        end
+
+      end
+    end
   end
 
   describe "#to_direction" do

--- a/spec/origin/extensions/symbol_spec.rb
+++ b/spec/origin/extensions/symbol_spec.rb
@@ -65,6 +65,44 @@ describe Symbol do
     it "returns the string with the value" do
       specified.should eq({ field: 10 })
     end
+
+    context "with a regexp" do
+
+      let(:specified) do
+        :field.specify(/test/)
+      end
+
+      it "returns the symbol with the value" do
+        specified.should eq({ field: /test/ })
+      end
+
+    end
+
+    context "when negated" do
+      context "with a regexp" do
+
+        let(:specified) do
+          :field.specify(/test/, true)
+        end
+
+        it "returns the symbol with the value negated" do
+          specified.should eq({ field: { "$not" => /test/ } })
+        end
+
+      end
+
+      context "with anything else" do
+
+        let(:specified) do
+          :field.specify('test', true)
+        end
+
+        it "returns the symbol with the value" do
+          specified.should eq({ field: 'test' })
+        end
+
+      end
+    end
   end
 
   describe "#to_direction" do


### PR DESCRIPTION
Here's a little excerpt MongoDB's [documentation](http://www.mongodb.org/display/DOCS/Advanced+Queries#AdvancedQueries-Metaoperator%3A%7B%7B%24not%7D%7D):

``` javascript
// The $not meta operator can be used to negate the check performed by a standard operator. For example:

db.customers.find( { name : { $not : /acme.*corp/i } } );

db.things.find( { a : { $not : { $mod : [ 10 , 1 ] } } } );
```

The [operators reference](http://docs.mongodb.org/manual/reference/operators/#_S_not) in the manual has some more information on using `$not` with regular expressions.

This pull request is my attempt to add a `:field.not` criterion while maintaining the current `query.not` functionality.  For regular expression values only, it allows the issue #44 syntax to work.

``` ruby
class User
  include Mongoid::Document
  field :name
end

# previously, this would not negate the regexp

User.not.where(name: /Andrew/).selector
  => { "name" => /Andrew/ }

# I changed the String and Symbol extensions to detect a regexp and consider it negatable

User.not.where(name: /Andrew/).selector
  => { "name" => { "$not" => /Andrew/ } }

# the following syntax also works

User.where(:name.not => /Andrew/).selector
  => { "name" => { "$not" => /Andrew/ } }

User.not(name: /Andrew/).selector
  => { "name" => { "$not" => /Andrew/ } }

# and finally, I have it check so double negatives don't happen

User.not.where(:name.not => /Andrew/).selector
  => { "name" => { "$not" => /Andrew/ } }
```

There may be a better way to accomplish including the `$not` for regular expressions, but I hope that the code and specs are helpful.  Thanks!
