### PR TITLE
Array of fields as argument to only and without

### DIFF
--- a/lib/origin/optional.rb
+++ b/lib/origin/optional.rb
@@ -124,6 +124,7 @@ module Origin
     #
     # @since 1.0.0
     def only(*args)
+      args = args.flatten
       option(*args) do |options|
         options.store(
           :fields, args.inject({}){ |sub, field| sub.tap { sub[field] = 1 }}
@@ -232,6 +233,7 @@ module Origin
     #
     # @since 1.0.0
     def without(*args)
+      args = args.flatten
       option(*args) do |options|
         options.store(
           :fields, args.inject({}){ |sub, field| sub.tap { sub[field] = 0 }}

--- a/spec/origin/optional_spec.rb
+++ b/spec/origin/optional_spec.rb
@@ -773,20 +773,40 @@ describe Origin::Optional do
       end
     end
 
-    context "when provided arguments" do
+    context "when provided fields" do
 
-      let(:selection) do
-        query.only(:first, :second)
+      context "as several arguments" do
+
+        let(:selection) do
+          query.only(:first, :second)
+        end
+
+        it "adds the field options" do
+          selection.options.should eq(
+            { fields: { "first" => 1, "second" => 1 }}
+          )
+        end
+
+        it "returns a cloned query" do
+          selection.should_not equal(query)
+        end
       end
 
-      it "adds the field options" do
-        selection.options.should eq(
-          { fields: { "first" => 1, "second" => 1 }}
-        )
-      end
+      context "as one argument - array" do
 
-      it "returns a cloned query" do
-        selection.should_not equal(query)
+        let(:selection) do
+          query.only([:first, :second])
+        end
+
+        it "adds the field options" do
+          selection.options.should eq(
+            { fields: { "first" => 1, "second" => 1 }}
+          )
+        end
+
+        it "returns a cloned query" do
+          selection.should_not equal(query)
+        end
       end
     end
   end
@@ -1665,20 +1685,40 @@ describe Origin::Optional do
       end
     end
 
-    context "when provided arguments" do
+    context "when provided fields" do
 
-      let(:selection) do
-        query.without(:first, :second)
+      context "as sevaral arguments" do
+
+        let(:selection) do
+          query.without(:first, :second)
+        end
+
+        it "adds the field options" do
+          selection.options.should eq(
+            { fields: { "first" => 0, "second" => 0 }}
+          )
+        end
+
+        it "returns a cloned query" do
+          selection.should_not equal(query)
+        end
       end
 
-      it "adds the field options" do
-        selection.options.should eq(
-          { fields: { "first" => 0, "second" => 0 }}
-        )
-      end
+      context "as one argument - array" do
 
-      it "returns a cloned query" do
-        selection.should_not equal(query)
+        let(:selection) do
+          query.without([:first, :second])
+        end
+
+        it "adds the field options" do
+          selection.options.should eq(
+            { fields: { "first" => 0, "second" => 0 }}
+          )
+        end
+
+        it "returns a cloned query" do
+          selection.should_not equal(query)
+        end
       end
     end
   end


### PR DESCRIPTION
Allow to pass array of fields as argument to `only` and `without` methods

Now you can call this methods in two ways:

  query.only(:first, :second)
  query.without(:first, :second)

  query.only([:first, :second])
  query.without([:first, :second])

Also it affects mongoid. It was possible to call exclusively `only` with array because it's overriden in Criteria to specify additional behavior, but `without` wasn't. Now you can use both of them with array argument.
