### PR TITLE
DateTime retains millisecond precision when evolving

### DIFF
--- a/lib/origin/extensions/date_time.rb
+++ b/lib/origin/extensions/date_time.rb
@@ -14,10 +14,11 @@ module Origin
       #
       # @since 1.0.0
       def __evolve_time__
+        usec = strftime("%6N").to_f
         if utc?
-          ::Time.utc(year, month, day, hour, min, sec)
+          ::Time.utc(year, month, day, hour, min, sec, usec)
         else
-          ::Time.local(year, month, day, hour, min, sec).utc
+          ::Time.local(year, month, day, hour, min, sec, usec).utc
         end
       end
 

--- a/spec/origin/extensions/date_time_spec.rb
+++ b/spec/origin/extensions/date_time_spec.rb
@@ -49,6 +49,24 @@ describe DateTime do
         evolved.utc_offset.should eq(0)
       end
     end
+
+    context "when the date time has millisecond precision" do
+      let(:date) do
+        DateTime.parse("2012-10-22T04:05:06.942")
+      end
+
+      let(:evolved) do
+        date.__evolve_time__
+      end
+
+      let(:expected) do
+        Time.utc(2012, 10, 22, 4, 5, 6, 942000)
+      end
+
+      it "returns the time with millisecond precision" do
+        evolved.should eq(expected)
+      end
+    end
   end
 
   describe ".evolve" do
@@ -73,6 +91,24 @@ describe DateTime do
 
       it "returns the time in utc" do
         evolved.utc_offset.should eq(0)
+      end
+    end
+
+    context "when provided a date time with millisecond precision" do
+      let(:date) do
+        DateTime.parse("2012-10-22T04:05:06.942")
+      end
+
+      let(:evolved) do
+        described_class.evolve(date)
+      end
+
+      let(:expected) do
+        Time.utc(2012, 10, 22, 4, 5, 6, 942000)
+      end
+
+      it "returns the time with millisecond precision" do
+        evolved.should eq(expected)
       end
     end
 


### PR DESCRIPTION
This fixes the problem of queries not keeping millisecond precision when querying as mentioned in mongoid/mongoid#2567
