### PR TITLE
Fix require on active_support_time_with_zone

### DIFF
--- a/lib/origin/extensions.rb
+++ b/lib/origin/extensions.rb
@@ -4,6 +4,9 @@ unless defined?(Boolean)
 end
 
 if defined?(ActiveSupport)
+  unless defined?(ActiveSupport::TimeWithZone)
+    require "active_support/time_with_zone"
+  end
   require "origin/extensions/time_with_zone"
 end
 


### PR DESCRIPTION
This case happens when ActiveSupport is present and cherry-picked.

Otherwise, origin failed with `uninitialized constant ActiveSupport::TimeWithZone (NameError)` in this context.

Signed-off-by: chatgris jboyer@af83.com
