### PR TITLE
Coerce non-array objects to Array in Origin::Extensions::Array::ClassMethods::evolve

### DIFF
--- a/lib/origin/extensions/array.rb
+++ b/lib/origin/extensions/array.rb
@@ -154,8 +154,10 @@ module Origin
         def evolve(object)
           if object.is_a?(::Array)
             object.map!{ |obj| obj.class.evolve(obj) }
+          elsif object.nil?
+            []
           else
-            object
+            evolve([object])
           end
         end
       end


### PR DESCRIPTION
Other field values seem to coerce to their specified field type, but Array does not.

If `person.name` is specified as type String, then `person.name = 75` results in `"75"`.

If `person.fake_names` is specified as type Array, then `person.fake_names = "Jim"` results in `"Jim"`, but the expected result should be `["Jim"]`.

**NOTE:** On line 160, you could alternatively do something like `evolve(object.split(/\s*,\s*/)) rescue evolve([object])` to make it assume that strings containing commas should be split into separate array elements.  I did not include it in this pull request because it may be an unnecessary assumption.
