### PR TITLE
Test on Ruby 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ bundler_args: --without development
 matrix:
   include:
     - rvm: 1.9.3
+    - rvm: 2.0.0
     - rvm: ruby-head
     - rvm: jruby-19mode
       jdk: oraclejdk7


### PR DESCRIPTION
The README states the Origin is tested on Ruby 2.0, but it isn’t actually (at least not on CI, though ruby-head is—but with failures allowed). This remedies that.
