### PR TITLE
Origin::Smash should respect aliases when fetching

### DIFF
--- a/lib/origin/smash.rb
+++ b/lib/origin/smash.rb
@@ -42,6 +42,10 @@ module Origin
       yield(self) if block_given?
     end
 
+    def [](key)
+      fetch(@aliases[key]) { super }
+    end
+
     private
 
     # Get the normalized value for the key. If localization is in play the

--- a/spec/origin/smash_spec.rb
+++ b/spec/origin/smash_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+
+describe Origin::Smash do
+  subject(:smash) { described_class.new(ns: :namespace) }
+
+  describe "#[]" do
+    before do
+      smash.store(:namespace, :default)
+      smash.store(:some_field, 42)
+    end
+
+    context "when accessing aliased field" do
+      it "returns value for original field" do
+        expect(smash[:ns]).to eq :default
+      end
+    end
+
+    context "when accessing non-aliased field" do
+      it "returns value for the field" do
+        expect(smash[:some_field]).to eq 42
+      end
+    end
+  end
+end


### PR DESCRIPTION
**TL;DR Origin doesn't merge selectors for aliases properly and this PR fixes that.**

I have just encountered this question on StackOverflow: http://stackoverflow.com/questions/16522040/intersecting-mongoid-in-queries

I was able to reproduce it. This happens when using field "names" that are actually aliases (`id` → `_id` and custom ones.)

Trying to identify the code that produced it, I traced it down to [Mergeable](https://github.com/mongoid/origin/blob/master/lib/origin/mergeable.rb#L235-242):

``` ruby
def with_strategy(strategy, criterion, operator)
  selection(criterion) do |selector, field, value|
    selector.store(
      field,
      selector[field].send(strategy, prepare(field, operator, value))
    )
  end
end
```

Now, it tries to perform `Selector#[]` with alias, not actual field name, so it gets nil, instead of selector for the real field. So it just uses the new selector. `Selector#store` does respect aliases, however, so it overrides the existing selector with the new one. (`Selector` is a subclass of `Smash`.)

There are actually two ways to fix this, in my opinion:
1. Make `Mergeable#with_strategy` try to resolve real field name itself and fetch appropriate selector for field.
2. Make `Selector#[]` ( `Smash#[]`) actually respect aliases that it was instantiated with.

I don't think `Mergeable#with_strategy` should care about actual field names at this point so I opted for the second way.
