### PR TITLE
Array.evolve that doesn't mutate its argument

### DIFF
--- a/lib/origin/extensions/array.rb
+++ b/lib/origin/extensions/array.rb
@@ -167,7 +167,7 @@ module Origin
         # @since 1.0.0
         def evolve(object)
           if object.is_a?(::Array)
-            object.map!{ |obj| obj.class.evolve(obj) }
+            object.map { |obj| obj.class.evolve(obj) }
           elsif object.nil?
             []
           else

--- a/spec/origin/extensions/array_spec.rb
+++ b/spec/origin/extensions/array_spec.rb
@@ -1,6 +1,37 @@
 require "spec_helper"
 
 describe Array do
+  describe ".evolve" do
+
+    context "when provided an Array" do
+
+      let(:array) do
+        [ 1, 2, 3 ]
+      end
+
+      it "returns an array" do
+        expect(described_class.evolve(array)).to eq([ 1, 2, 3 ])
+      end
+
+      it "doesn't mutate its argument" do
+        expect(described_class.evolve(array.freeze)).not_to raise_error
+      end
+    end
+
+    context "when provided nil" do
+
+      it "returns an array" do
+        expect(described_class.evolve(nil)).to eq([])
+      end
+    end
+
+    context "when provided another object" do
+
+      it "returns the object" do
+        expect(described_class.evolve("testing")).to eq(["testing"])
+      end
+    end
+  end
 
   describe "#__add__" do
 


### PR DESCRIPTION
We were getting a `can't modify frozen Array` error when our application code was simply calling an attribute setter on a mongoid instance. The `map!` in this method turned out to be the culprit...

Thanks for the libraries!
