### PR TITLE
use serializer.evolve when `value` and `serializer.type` are both arrays

### DIFF
--- a/lib/origin/selector.rb
+++ b/lib/origin/selector.rb
@@ -106,7 +106,11 @@ module Origin
       when Hash
         evolve_hash(serializer, value)
       when Array
-        evolve_array(serializer, value)
+        if serializer && serializer.type == Array
+          serializer.evolve(value)
+        else
+          evolve_array(serializer, value)
+        end
       else
         (serializer || value.class).evolve(value)
       end


### PR DESCRIPTION
prevents coercing array values into arrays themselves

see PR https://github.com/mongoid/origin/pull/66#issuecomment-19488081
