### PR TITLE
[DNM] Protect query methods from insecure parameters:

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ gemspec
 
 group :test do
   gem "activesupport", "~> 4.0"
+  gem "actionpack", "~> 4.0"
   gem "i18n", "~> 0.6"
   gem "rspec", "~> 3.0.0.beta1"
   gem "tzinfo", "~> 0.3.22"

--- a/lib/origin.rb
+++ b/lib/origin.rb
@@ -1,4 +1,10 @@
 # encoding: utf-8
+unless defined?(ActionController)
+  module ActionController
+    class Parameters; end
+  end
+end
+
 require "origin/forwardable"
 require "origin/queryable"
 require "origin/version"

--- a/lib/origin/mergeable.rb
+++ b/lib/origin/mergeable.rb
@@ -148,8 +148,10 @@ module Origin
         sel = query.selector
         criterion.flatten.each do |expr|
           next unless expr
+          check_security!(expr)
           criteria = sel[operator] || []
           normalized = expr.inject({}) do |hash, (field, value)|
+            check_security!(value)
             hash.merge!(field.__expr_part__(value.__expand_complex__))
             hash
           end

--- a/lib/origin/selectable.rb
+++ b/lib/origin/selectable.rb
@@ -583,9 +583,11 @@ module Origin
     #
     # @since 1.0.0
     def selection(criterion = nil)
+      check_security!(criterion)
       clone.tap do |query|
         if criterion
           criterion.each_pair do |field, value|
+            check_security!(value)
             yield(query.selector, field.is_a?(Key) ? field : field.to_s, value)
           end
         end

--- a/spec/origin/selectable_spec.rb
+++ b/spec/origin/selectable_spec.rb
@@ -13,6 +13,27 @@ describe Origin::Selectable do
     end
   end
 
+  shared_examples_for "a secure selectable" do
+
+    let(:params) do
+      ActionController::Parameters.new(email: { "$elemMatch" => { foo: "bar" }})
+    end
+
+    context "when passing params directly" do
+
+      it "does not allow direct passing of action controller parameters" do
+        expect { insecure_params }.to raise_error(Origin::Queryable::Insecure)
+      end
+    end
+
+    context "when a value is a params object" do
+
+      it "does not allow direct passing of action controller parameters" do
+        expect { insecure_value }.to raise_error(Origin::Queryable::Insecure)
+      end
+    end
+  end
+
   describe "#all" do
 
     context "when provided no criterion" do
@@ -391,6 +412,19 @@ describe Origin::Selectable do
   end
 
   describe "#and" do
+
+    context "when provided insecure parameters" do
+
+      let(:insecure_params) do
+        query.and(params)
+      end
+
+      let(:insecure_value) do
+        query.and(email: params[:email])
+      end
+
+      it_behaves_like "a secure selectable"
+    end
 
     context "when provided no criterion" do
 
@@ -2474,6 +2508,19 @@ describe Origin::Selectable do
 
   describe "#nor" do
 
+    context "when provided insecure parameters" do
+
+      let(:insecure_params) do
+        query.nor(params)
+      end
+
+      let(:insecure_value) do
+        query.nor(email: params[:email])
+      end
+
+      it_behaves_like "a secure selectable"
+    end
+
     context "when provided no criterion" do
 
       let(:selection) do
@@ -2837,6 +2884,19 @@ describe Origin::Selectable do
 
   describe "#or" do
 
+    context "when provided insecure parameters" do
+
+      let(:insecure_params) do
+        query.or(params)
+      end
+
+      let(:insecure_value) do
+        query.or(email: params[:email])
+      end
+
+      it_behaves_like "a secure selectable"
+    end
+
     context "when provided no criterion" do
 
       let(:selection) do
@@ -3194,7 +3254,7 @@ describe Origin::Selectable do
     end
   end
 
-  describe "#type" do
+  describe "#with_type" do
 
     context "when provided no criterion" do
 
@@ -3332,6 +3392,19 @@ describe Origin::Selectable do
   end
 
   describe "#where" do
+
+    context "when provided insecure parameters" do
+
+      let(:insecure_params) do
+        query.where(params)
+      end
+
+      let(:insecure_value) do
+        query.where(email: params[:email])
+      end
+
+      it_behaves_like "a secure selectable"
+    end
 
     context "when provided no criterion" do
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ end
 
 require "i18n"
 require "active_support/time"
+require "action_controller"
 require "origin"
 require "rspec"
 


### PR DESCRIPTION
Raises an exception if ActionController::Parameters are passed directly
to a query method, or are a value passed to a query method.

This applies to `where`, `and`, `or`, and `nor`.

[ SECURITY-90 ]
