### PR TITLE
Add __FILE__, __LINE__ to class-, module_eval calls

### DIFF
--- a/lib/origin/forwardable.rb
+++ b/lib/origin/forwardable.rb
@@ -44,13 +44,13 @@ module Origin
     # @since 1.0.0
     def __forward__(name, receiver)
       if self.class == Module
-        module_eval <<-SEL
+        module_eval <<-SEL, __FILE__, __LINE__
           def #{name}(*args, &block)
             #{receiver}.__send__(:#{name}, *args, &block)
           end
         SEL
       else
-        (class << self; self; end).class_eval <<-SEL
+        (class << self; self; end).class_eval <<-SEL, __FILE__, __LINE__
           def #{name}(*args, &block)
             #{receiver}.__send__(:#{name}, *args, &block)
           end


### PR DESCRIPTION
Sometimes when exploring or debugging code it's necessary to know where
some method was defined. For this purpose `Method#source_location` is
used. It reports a filename and a line in the file with a method
definition. However, when using `Module#class_eval` and
`Module#module_eval` to dynamically define methods,
the output of `Method#source_location` is uninformative.

For this reason it's better to add `__FILE__` and `__LINE__` constants
as the second and third arguments to the aforementioned methods. This
allows `Method#source_location` to properly locate methods which was
defined dynamically.

Here's some examples:

    require 'origin'

    class Band
      extend Origin::Forwardable

      select_with :queryable

      def self.queryable
        Object.new.extend Origin::Queryable
      end
    end

    Band.method(:where).source_location
      # without __FILE__, __LINE__
      #=> ["(eval)", 1]

      # with __FILE__, __LINE__
      #=> ["<...>/lib/origin/forwardable.rb", 53]

    require 'origin'

    module Finders
      extend Origin::Forwardable

      select_with :queryable

      def queryable
        Object.new.extend Origin::Queryable
      end
    end

    class Band
      extend Finders
    end

    Band.method(:where).source_location
      # without __FILE__, __LINE__
      #=> ["(eval)", 1]

      # with __FILE__, __LINE__
      #=> ["<...>/lib/origin/forwardable.rb", 47]